### PR TITLE
Red/green color blind theme + failure details

### DIFF
--- a/src/main/webapp/utils.js
+++ b/src/main/webapp/utils.js
@@ -97,12 +97,12 @@ function removeMessage()
 	$("#Message").remove()
 }
 
-function getLongestJob(jobs) {
+function getLongestJob(jobs, showDetails) {
 
 	var job = null;
 
 	$.each(jobs, function(index, currentJob) { 
-		if (job == null || getJobText(currentJob).length > getJobText(job).length)
+		if (job == null || getJobText(currentJob, showDetails).length > getJobText(job, showDetails).length)
 		{
 			job = currentJob;
 		}
@@ -128,11 +128,37 @@ function getJobTitle(job) {
 	return jobTitle;
 }
 
-function getJobText(job) {  
+function getJobText(job, showDetails) {  
 
 	var jobText = getJobTitle(job);
 
+	if (showDetails == "true") {
+		var culprit = getCulprit(job);
+		if (job.color == "yellow") {
+			jobText += " (" + job.lastBuild.actions[4].failCount + "/" + job.lastBuild.actions[4].totalCount;
+			if(culprit != "") {
+				jobText += ", " + culprit;
+			}
+			jobText += ")";
+		}
+		if (job.color == "red") {
+			if(culprit != "") {
+				jobText += " (" + culprit + ")";
+			}
+		}		
+	}
+	
 	return jobText;
+}
+
+function getCulprit(job) {
+	var culprit = "";
+		
+	if(job.lastBuild != null && job.lastBuild.culprits != "") {
+		culprit = job.lastBuild.culprits[0].fullName
+	}
+	
+	return culprit;
 }
 
 function isNumber(n) {

--- a/src/main/webapp/walldisplay.html
+++ b/src/main/webapp/walldisplay.html
@@ -103,7 +103,7 @@
 
 		function getJobDimensions(job, fontSize) {
 
-			var textDimensions = getTextDimensions(getJobText(job), fontSize);
+			var textDimensions = getTextDimensions(getJobText(job, showDetails), fontSize);
 
 			var dimension = {};
 			dimension.width = textDimensions.width + 2 * jobPadding + 2 * jobBorderWidth;
@@ -160,7 +160,7 @@
 					});
 					
 					
-					var longestJob = getLongestJob(jobsToDisplay);
+					var longestJob = getLongestJob(jobsToDisplay, showDetails);
 					var maxFontSize = 0;
 					
 					for (var columnCount = 1; columnCount <= jobsToDisplay.length; columnCount++) {  
@@ -268,7 +268,7 @@
 								});
 								jobContent.addClass("job_content");
 								jobContent.css(jobDimensionsStyle);
-								jobContent.text(getJobText(job));
+								jobContent.text(getJobText(job, showDetails));
 	
 								//- create the job wrapper div ---------------------
 								var jobWrapper = $('<div />').attr({
@@ -328,7 +328,7 @@
 						url: jenkinsUrl +  "/job/" + jobName + "/api/json",
 						dataType: "json",
 						data: {
-							"tree": "property[wallDisplayName],name,color,lastBuild[number,timestamp,duration],lastSuccessfulBuild[duration]"
+							"tree": "property[wallDisplayName],name,color,lastBuild[number,timestamp,duration,actions[failCount,skipCount,totalCount],culprits[fullName]],lastSuccessfulBuild[duration]"
 						},
 						success: function(job, textStatus, jqXHR) {
 							debug("finished getting api for job '" + jobName + "'");
@@ -347,7 +347,7 @@
 								jobsToDisplay[jobsToDisplay.length] = job;
 							}
 							
-							jobsToDisplay.sort(function(job1, job2) { return getJobText(job1).localeCompare(getJobText(job2)); });
+							jobsToDisplay.sort(function(job1, job2) { return getJobText(job1, showDetails).localeCompare(getJobText(job2, showDetails)); });
 							
 							updateRunning[jobName] = false;
 						},
@@ -414,7 +414,7 @@
 
 				for (var fontSize = 10; fontSize <= 302; fontSize++) {
 					
-					var textDimensions = getTextDimensions(getJobText(job, fontSize));
+					var textDimensions = getTextDimensions(getJobText(job, showDetails), fontSize);
 
 					if (textDimensions.width <= (jobInfoWidth - jobInfoPadding) && textDimensions.height <= (jobInfoHeight - jobInfoPadding))
 					{
@@ -636,6 +636,7 @@
 		var jenkinsUrl = getParameterByName("jenkinsUrl",  window.location.protocol + "://" + window.location.host + "/" + window.location.pathname.replace("plugin/jenkinswalldisplay/walldisplay.html", ""));
 		var viewName = getParameterByName("viewName", "All");
 		var theme = getParameterByName("theme", "default");
+		var showDetails = getParameterByName("details", "false");
 		var maxQueuePositionToShow = 15;
 
 		var isDebug = false;


### PR DESCRIPTION
I added a theme for red/green color blind people (&theme=cb), an option to show the name of the culprit when a build fails and the number of failed tests/total tests when tests fail (&details=true).
