### PR TITLE
Added option to omit disabled builds

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>jenkinswalldisplay</artifactId>
     <packaging>hpi</packaging>
-    <version>0.6.11-SNAPSHOT</version>
+    <version>0.6.12-SNAPSHOT</version>
     <name>Jenkins Wall Display Master Project</name>
     <url>http://wiki.jenkins-ci.org/display/JENKINS/Wall+Display+Plugin</url>
     

--- a/src/main/java/de/pellepelster/jenkins/walldisplay/Configuration.java
+++ b/src/main/java/de/pellepelster/jenkins/walldisplay/Configuration.java
@@ -22,6 +22,7 @@ public class Configuration {
     private int jenkinsUpdateInterval = 20;
     private Boolean showDetails = false;
     private Boolean showBuildNumber = true;
+    private Boolean showDisabledBuilds = true;
 
     @Exported
     public Boolean getShowBuildNumber() {
@@ -30,6 +31,15 @@ public class Configuration {
 
     public void setShowBuildNumber(Boolean showBuildNumber) {
         this.showBuildNumber = showBuildNumber;
+    }
+
+    @Exported
+    public Boolean getShowDisabledBuilds() {
+        return showDisabledBuilds;
+    }
+
+    public void setShowDisabledBuilds(Boolean showDisabledBuilds) {
+        this.showDisabledBuilds = showDisabledBuilds;
     }
 
     @Exported

--- a/src/main/java/de/pellepelster/jenkins/walldisplay/WallDisplayPlugin.java
+++ b/src/main/java/de/pellepelster/jenkins/walldisplay/WallDisplayPlugin.java
@@ -72,6 +72,7 @@ public class WallDisplayPlugin extends Plugin {
         config.setJenkinsUpdateInterval(formData.optInt("jenkinsUpdateInterval"));
         config.setShowBuildNumber(formData.optBoolean("jenkinsShowBuildNumber"));
         config.setShowDetails(formData.optBoolean("jenkinsShowDetails"));
+        config.setShowDisabledBuilds(formData.optBoolean("jenkinsShowDisabledBuilds"));
         
         getConfigXml().write(config);
     }

--- a/src/main/resources/de/pellepelster/jenkins/walldisplay/WallDisplayPlugin/config.jelly
+++ b/src/main/resources/de/pellepelster/jenkins/walldisplay/WallDisplayPlugin/config.jelly
@@ -26,5 +26,9 @@
             <f:checkbox name="jenkinsShowBuildNumber" checked="${it.config.showBuildNumber}" />
         </f:entry> 
 
+        <f:entry title="${%Show Disabled Builds}" name="jenkinsShowDisabledBuilds">
+            <f:checkbox name="jenkinsShowDisabledBuilds" checked="${it.config.showDisabledBuilds}" />
+        </f:entry>
+
     </f:section>
 </j:jelly>

--- a/src/main/webapp/walldisplay.html
+++ b/src/main/webapp/walldisplay.html
@@ -373,7 +373,12 @@
 									jobsToDisplay[index] = job;
 									add = false;
 								}
+                                                                
 							});
+
+							if(!showDisabledBuilds && job.color === 'disabled') {
+								add = false;
+							}
 							
 							if (add)
 							{
@@ -623,6 +628,11 @@
                         showBuildNumber = plugin.config.showBuildNumber;
                     }
 
+                    if (plugin.config && plugin.config.showDisabledBuilds != null)
+                    {
+                        showDisabledBuilds = plugin.config.showDisabledBuilds;
+                    }
+
                     if (isNumber(plugin.config.jenkinsUpdateInterval))
                     {
                         jenkinsUpdateInterval = plugin.config.jenkinsUpdateInterval * 1000;
@@ -681,6 +691,7 @@
 		var theme = getParameterByName("theme", "default");
 		var showDetails = false;
 		var showBuildNumber = true;
+		var showDisabledBuilds = true;
 		var maxQueuePositionToShow = 15;
 
 		var isDebug = false;


### PR DESCRIPTION
I added a checkbox to omit disabled builds. Would this be useful to other users? We didn't want our disabled builds on our screen as they're either templates or deactivated for some reason.
