### PR TITLE
Build fails in Java 7 (fix)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>1.399</version>
+        <version>1.484</version>
     </parent>
 
     <groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION
...work in Java 7.

Full cause:

Plugin did not build in Java7:
    $ java -version
    java version "1.7.0_03"
    OpenJDK Runtime Environment (IcedTea7 2.1.1) (7~u3-2.1.1-1)
    OpenJDK 64-Bit Server VM (build 22.0-b10, mixed mode)
- Because it depended on org.jenkins-ci.plugins:plugin:1.399, which in turn
  needed: com.sun.mirror.apt.AnnotationProcessorFactory, which was deprecated in Java 6 and removed in Java 7.

This caused "mvn clean package" under Java 7 to fail with:

[INFO] --- maven-hpi-plugin:1.64:apt-compile (default-apt-compile) @ jenkinswalldisplay ---
okt 01, 2012 3:30:48 EM org.sonatype.guice.bean.reflect.Logs$JULSink warn
Varning: Error injecting: org.jvnet.hudson.maven.plugins.hpi.AptCompiler
java.lang.NoClassDefFoundError: com/sun/mirror/apt/AnnotationProcessorFactory
    at java.lang.Class.getDeclaredConstructors0(Native Method)
    at java.lang.Class.privateGetDeclaredConstructors(Class.java:2404)
    at java.lang.Class.getDeclaredConstructors(Class.java:1853)
    at com.google.inject.spi.InjectionPoint.forConstructorOf(InjectionPoint.java:245)
    at com.google.inject.internal.ConstructorBindingImpl.create(ConstructorBindingImpl.java:98)
    at com.google.inject.internal.InjectorImpl.createUninitializedBinding(InjectorImpl.java:629)
    at com.google.inject.internal.InjectorImpl.createJustInTimeBinding(InjectorImpl.java:831)
    at com.google.inject.internal.InjectorImpl.createJustInTimeBindingRecursive(InjectorImpl.java:758)
    at com.google.inject.internal.InjectorImpl.getJustInTimeBinding(InjectorImpl.java:255)
    at com.google.inject.internal.InjectorImpl.getBindingOrThrow(InjectorImpl.java:204)
    at com.google.inject.internal.InjectorImpl.getProviderOrThrow(InjectorImpl.java:954)
    at com.google.inject.internal.InjectorImpl.getProvider(InjectorImpl.java:987)
    at com.google.inject.internal.InjectorImpl.getProvider(InjectorImpl.java:950)
    at com.google.inject.internal.InjectorImpl.getInstance(InjectorImpl.java:1000)
    at org.sonatype.guice.bean.reflect.AbstractDeferredClass.get(AbstractDeferredClass.java:45)
    at com.google.inject.internal.ProviderInternalFactory.provision(ProviderInternalFactory.java:84)
    at com.google.inject.internal.InternalFactoryToInitializableAdapter.provision(InternalFactoryToInitializableAdapter.java:52)
    at com.google.inject.internal.ProviderInternalFactory$1.call(ProviderInternalFactory.java:70)
    at com.google.inject.internal.ProvisionListenerStackCallback$Provision.provision(ProvisionListenerStackCallback.java:100)
    at org.sonatype.guice.plexus.lifecycles.PlexusLifecycleManager.onProvision(PlexusLifecycleManager.java:138)
    at com.google.inject.internal.ProvisionListenerStackCallback$Provision.provision(ProvisionListenerStackCallback.java:108)
    at com.google.inject.internal.ProvisionListenerStackCallback.provision(ProvisionListenerStackCallback.java:55)
    at com.google.inject.internal.ProviderInternalFactory.circularGet(ProviderInternalFactory.java:68)
    at com.google.inject.internal.InternalFactoryToInitializableAdapter.get(InternalFactoryToInitializableAdapter.java:45)
    at com.google.inject.internal.ProviderToInternalFactoryAdapter$1.call(ProviderToInternalFactoryAdapter.java:46)
    at com.google.inject.internal.InjectorImpl.callInContext(InjectorImpl.java:1018)
    at com.google.inject.internal.ProviderToInternalFactoryAdapter.get(ProviderToInternalFactoryAdapter.java:40)
    at com.google.inject.Scopes$1$1.get(Scopes.java:59)
    at com.google.inject.internal.InternalFactoryToProviderAdapter.get(InternalFactoryToProviderAdapter.java:41)
    at com.google.inject.internal.InjectorImpl$3$1.call(InjectorImpl.java:965)
    at com.google.inject.internal.InjectorImpl.callInContext(InjectorImpl.java:1011)
    at com.google.inject.internal.InjectorImpl$3.get(InjectorImpl.java:961)
    at org.sonatype.guice.bean.locators.LazyBeanEntry.getValue(LazyBeanEntry.java:83)
    at org.sonatype.guice.plexus.locators.LazyPlexusBean.getValue(LazyPlexusBean.java:49)
    at java.util.AbstractMap.get(AbstractMap.java:182)
    at org.codehaus.plexus.compiler.manager.DefaultCompilerManager.getCompiler(DefaultCompilerManager.java:54)
    at org.jvnet.hudson.maven.plugins.hpi.AbstractCompilerMojo.execute(AbstractCompilerMojo.java:260)
    at org.jvnet.hudson.maven.plugins.hpi.CompilerMojo.execute(CompilerMojo.java:111)
    at org.jvnet.hudson.maven.plugins.hpi.AptMojo.execute(AptMojo.java:24)
    at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo(DefaultBuildPluginManager.java:101)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:209)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:153)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:145)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:84)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:59)
    at org.apache.maven.lifecycle.internal.LifecycleStarter.singleThreadedBuild(LifecycleStarter.java:183)
    at org.apache.maven.lifecycle.internal.LifecycleStarter.execute(LifecycleStarter.java:161)
    at org.apache.maven.DefaultMaven.doExecute(DefaultMaven.java:320)
    at org.apache.maven.DefaultMaven.execute(DefaultMaven.java:156)
    at org.apache.maven.cli.MavenCli.execute(MavenCli.java:537)
    at org.apache.maven.cli.MavenCli.doMain(MavenCli.java:196)
    at org.apache.maven.cli.MavenCli.main(MavenCli.java:141)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke(Method.java:601)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced(Launcher.java:290)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launch(Launcher.java:230)
    at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode(Launcher.java:409)
    at org.codehaus.plexus.classworlds.launcher.Launcher.main(Launcher.java:352)
Caused by: java.lang.ClassNotFoundException: com.sun.mirror.apt.AnnotationProcessorFactory
    at org.codehaus.plexus.classworlds.strategy.SelfFirstStrategy.loadClass(SelfFirstStrategy.java:50)
    at org.codehaus.plexus.classworlds.realm.ClassRealm.loadClass(ClassRealm.java:244)
    at org.codehaus.plexus.classworlds.realm.ClassRealm.loadClass(ClassRealm.java:230)
    ... 60 more
