### PR TITLE
org.jenkins-ci.plugins:plugin version -> 1.424

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>1.484</version>
+        <version>1.424</version>
     </parent>
 
     <groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION
According to this discussion [https://github.com/jenkinsci/walldisplay-plugin/pull/13]
it's the least invasive change that still fixes the issue with building on Java 7.
