### PR TITLE
Full screen mode on iOS devices

### DIFF
--- a/src/main/webapp/walldisplay.html
+++ b/src/main/webapp/walldisplay.html
@@ -1,6 +1,9 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="black" />
+    
 	<title>Jenkins Wall Display</title>
 
 	<link type="text/css" rel="stylesheet" media="all" href="walldisplay.css" />


### PR DESCRIPTION
This will allow the wall to be displayed in full screen on iOS devices
when bookmarking the web page on the homescreen.

Very usefull for using an iPad to display the Wall
