### PR TITLE
lastPaintInterval javascript variable was not defined causing painting error

### DIFF
--- a/src/main/webapp/walldisplay.html
+++ b/src/main/webapp/walldisplay.html
@@ -801,6 +801,9 @@
 
 		var jenkinsUpdateInterval = getParameterByName("jenkinsUpdateInterval", 20000);
 		var lastJenkinsUpdateInterval = jenkinsUpdateInterval;
+		
+		var paintInterval = getParameterByName("jenkinsPaintInterval", 100);
+		var lastPaintInterval = paintInterval;
 
 		var jenkinsUrl = getParameterByName("jenkinsUrl",  window.location.protocol + "://" + window.location.host + "/" + window.location.pathname.replace("plugin/jenkinswalldisplay/walldisplay.html", ""));
 		var viewName = getParameterByName("viewName", "All");


### PR DESCRIPTION
Added a declaration of the lastPaintInterval variable that will later be referenced.
