### PR TITLE
JS error when trying to display an "external job"

### DIFF
--- a/src/main/webapp/utils.js
+++ b/src/main/webapp/utils.js
@@ -172,7 +172,7 @@ function getGravatarUrl(job, showGravatar, size) {
 function getEmail(job) {
     var email = "";
 
-    if(job.lastBuild != null && job.lastBuild.culprits != "") {
+    if(job.lastBuild != null && job.lastBuild.culprits != null && job.lastBuild.culprits != "") {
        for(i in job.lastBuild.culprits[0].property) {
           email = job.lastBuild.culprits[0].property[i].address || email;
        }
@@ -184,7 +184,7 @@ function getEmail(job) {
 function getCulprit(job) {
 	var culprit = "";
 
-	if(job.lastBuild != null && job.lastBuild.culprits != "") {
+	if(job.lastBuild != null && job.lastBuild.culprits != null && job.lastBuild.culprits != "") {
 		culprit = job.lastBuild.culprits[0].fullName
 	}
 


### PR DESCRIPTION
Apparently, a "monitor external job" does not have a culprit.
Adding a check in the JS to prevent access to an undefined array,
that prevented the screen to be rendered.
