### PR TITLE
New option to blink background pictures of jobs when building

### DIFF
--- a/src/main/java/de/pellepelster/jenkins/walldisplay/Configuration.java
+++ b/src/main/java/de/pellepelster/jenkins/walldisplay/Configuration.java
@@ -29,6 +29,7 @@ public class Configuration {
     private Boolean showBuildNumber = true;
     private Boolean showLastStableTimeAgo = true;
     private Boolean showDisabledBuilds = true;
+    private Boolean blinkBgPicturesWhenBuilding = false;
 
     @Exported
     public Boolean getShowBuildNumber() {
@@ -174,7 +175,16 @@ public class Configuration {
     public void setFontFamily(String fontFamily) {
         this.fontFamily = fontFamily;
     }
-    
+
+    @Exported
+    public Boolean getBlinkBgPicturesWhenBuilding () {
+        return blinkBgPicturesWhenBuilding;
+    }
+
+    public void setBlinkBgPicturesWhenBuilding (Boolean blinkBgPicturesWhenBuilding) {
+        this.blinkBgPicturesWhenBuilding = blinkBgPicturesWhenBuilding;
+    }
+
     /**
      * {@inheritDoc}
      */

--- a/src/main/java/de/pellepelster/jenkins/walldisplay/WallDisplayPlugin.java
+++ b/src/main/java/de/pellepelster/jenkins/walldisplay/WallDisplayPlugin.java
@@ -81,6 +81,7 @@ public class WallDisplayPlugin extends Plugin {
         config.setJenkinsTimeOut(formData.optInt("jenkinsTimeOut"));
         config.setJenkinsUpdateInterval(formData.optInt("jenkinsUpdateInterval"));
         config.setShowLastStableTimeAgo (formData.optBoolean("jenkinsLastStableTimeAgo"));
+        config.setBlinkBgPicturesWhenBuilding (formData.optBoolean("blinkBgPicturesWhenBuilding"));
         config.setShowBuildNumber(formData.optBoolean("jenkinsShowBuildNumber"));
         config.setShowDetails(formData.optBoolean("jenkinsShowDetails"));
         config.setShowGravatar(formData.optBoolean("jenkinsShowGravatar"));

--- a/src/main/resources/de/pellepelster/jenkins/walldisplay/WallDisplayPlugin/config.jelly
+++ b/src/main/resources/de/pellepelster/jenkins/walldisplay/WallDisplayPlugin/config.jelly
@@ -57,6 +57,10 @@
             <f:checkbox name="jenkinsShowDetails" checked="${it.config.showDetails}" />
         </f:entry>
 
+        <f:entry title="${%Blink Background Pictures When Building}" name="jenkinsBlinkBackgroundPicturesWhenBuilding" help="${rootURL}/../plugin/jenkinswalldisplay/help-globalConfig-jenkinsBlinkBgPicturesWhenBuilding.html">
+            <f:checkbox name="blinkBgPicturesWhenBuilding" checked="${it.config.blinkBgPicturesWhenBuilding}" />
+        </f:entry>
+        
         <f:entry title="${%Show Job Show Gravatar}" name="jenkinsShowGravatar" help="${rootURL}/../plugin/jenkinswalldisplay/help-globalConfig-jenkinsShowGravatar.html">
             <f:checkbox name="jenkinsShowGravatar" checked="${it.config.showGravatar}" />
         </f:entry>

--- a/src/main/webapp/help-globalConfig-jenkinsBlinkBgPicturesWhenBuilding.html
+++ b/src/main/webapp/help-globalConfig-jenkinsBlinkBgPicturesWhenBuilding.html
@@ -1,0 +1,6 @@
+<div>
+    <p>
+        Check this box to make background pictures of jobs blink when a build is in progress.
+        Only works if there is a background picture on a job.
+    </p>
+</div>

--- a/src/main/webapp/help-globalConfig-jenkinsLastStableTimeAgo.html
+++ b/src/main/webapp/help-globalConfig-jenkinsLastStableTimeAgo.html
@@ -1,5 +1,5 @@
 <div>
     <p>
-        Check this box to show the the last stable build time ago.
+        Check this box to show the last stable build time ago.
     </p>
 </div>

--- a/src/main/webapp/walldisplay.html
+++ b/src/main/webapp/walldisplay.html
@@ -139,7 +139,11 @@
 			}
 		}
 
-
+		function blink (objs){
+			objs.fadeTo(blinkInterval, 0.33)
+			.fadeTo(blinkInterval, 1, function(){blink(objs)});
+		}
+		
 		function repaint()
 		{
 			if (updateError != null)
@@ -342,6 +346,8 @@
 											"width":Math.floor ((jobWidth - 2 * claimedBorderWidth)/6) + "px",
 											"height":(jobHeight - 2 * claimedBorderWidth) + "px",
 										});
+										jobBg.addClass (
+												(!isBuilding ? "in" : "") + "activeJob");
 										jobWrapper.append(jobBg);
 									}
 								});
@@ -350,7 +356,7 @@
 								$.each(queueDivs, function(index, queueDiv) {
 									jobWrapper.append(queueDiv);
 								});
-
+								
 								jobWrapper.click({ "job": job },function(eventData) {
 									showJobinfo(eventData.data.job);
 								});
@@ -359,6 +365,14 @@
 
 								jobIndex++;
 							}
+						}
+						
+						if (!blinkBgPicturesWhenBuilding){
+						  $(".activeJob").clearQueue ();
+						}else{
+						  if (jQuery.queue ($(".activeJob"),"fx").length == 0){
+						    blink ($(".activeJob"));
+						  }
 						}
 					}
 				}
@@ -598,18 +612,6 @@
 
 
 				$("body").append(jobInfoDiv);
-
-				/*
-				jobInfoDiv.fadeTo(1500, 0.95, function() {
-
-					setInterval(function() {
-						jobInfoDiv.fadeTo(1500, 0.0, function() {
-							$("#JobInfo").remove();
-						}
-						);
-					}, jobInfoTimout);
-				});
-				*/
 			}
 		}
 
@@ -752,6 +754,11 @@
 							showLastStableTimeAgo = plugin.config.showLastStableTimeAgo;
 						}
 
+						if (plugin.config.blinkBgPicturesWhenBuilding != null)
+						{
+							blinkBgPicturesWhenBuilding = plugin.config.blinkBgPicturesWhenBuilding;
+						}
+
 						if (plugin.config.showDisabledBuilds != null)
 						{
 							showDisabledBuilds = plugin.config.showDisabledBuilds;
@@ -765,6 +772,12 @@
 						if (isNumber(plugin.config.paintInterval))
 						{
 							paintInterval = plugin.config.paintInterval * 1000;
+							//Blink interval is the time interval for fadingOut/fadingIn
+							//of background pictures of jobs
+							blinkInterval = paintInterval;
+							do {
+								blinkInterval /= 2;
+							} while (blinkInterval > 1500);
 						}
 
 						if (isNumber(plugin.config.jenkinsTimeOut))
@@ -833,6 +846,7 @@
 		var lastJenkinsUpdateInterval = jenkinsUpdateInterval;
 		
 		var paintInterval = getParameterByName("jenkinsPaintInterval", 100);
+		var blinkInterval = 500;
 		var lastPaintInterval = paintInterval;
 
 		var jenkinsUrl = getParameterByName("jenkinsUrl",  window.location.protocol + "://" + window.location.host + "/" + window.location.pathname.replace("plugin/jenkinswalldisplay/walldisplay.html", ""));
@@ -847,6 +861,7 @@
 		var gravatarCounter = {};
 		var showBuildNumber = true;
 		var showLastStableTimeAgo = true;
+		var blinkBgPicturesWhenBuilding = false;
 		var showDisabledBuilds = true;
 		var maxQueuePositionToShow = 15;
 		


### PR DESCRIPTION
Hi @pellepeister,

I made a new feature to be able to blink background pictures of jobs being built.
You can test this feature by yourself. It's smooth and without bug.

You can enable/disable it with an option in the config. The display of jobs without this option is still working.

Regards,
@libetl (Lionel)
