### PR TITLE
Minor JavaScript issue can prevent jobs from being displayed when showWeatherReport is set to true

### DIFF
--- a/src/main/webapp/walldisplay.js
+++ b/src/main/webapp/walldisplay.js
@@ -119,6 +119,12 @@ function isJobBuilding(job) {
     return job.color.substr(-6) === "_anime";    
 }
 
+function jobHasHealthReport(job) {
+    var healthReport = job.healthReport;
+
+    return healthReport[0] !== undefined;
+}
+
 function repaint(){
     if(updateError != null){
         displayMessage(updateError, "message_error");
@@ -281,7 +287,7 @@ function repaint(){
                         jobWrapper.addClass(theme);
                         jobWrapper.addClass(jobColor);
 
-                        if (showWeatherReport)
+                        if (showWeatherReport && jobHasHealthReport(job))
                         {
                             var jobWeatherReport = $('<div />');
 


### PR DESCRIPTION
In order to recreate this issue, create a new free-style build job, save it, but do not run the job. When viewing the wall display page (and given that showWeatherReport is set to true), jobs listed after the newly created job will not be displayed. This is caused by an attempt to access the health report score for the new, yet-to-be-built job, which stops the rest of the jobs from being rendered. The JavaScript error message is 'TypeError: job.healthReport[0] is undefined'.

This pull request includes a small update to walldisplay.js that fixes this by first checking if a job has a healthReport available.

This has been tested on a local copy of Jenkins (ver. 1.560), running on Ubuntu 14.04 in Firefox 29.0, using version 0.6.23 of the wall display plugin; I haven't confirmed cross-browser compatibility.
