### PR TITLE
When there are no jobs for the filter to show, it will print 'No jobs to display'

### DIFF
--- a/src/main/webapp/walldisplay.js
+++ b/src/main/webapp/walldisplay.js
@@ -128,8 +128,10 @@ function jobHasHealthReport(job) {
 function repaint(){
     if(updateError != null){
         displayMessage(updateError, "message_error");
-    }else if(jobsToDisplay.length == 0){
+    }else if(updateRunning[viewName]){
         displayMessage("Loading jobs...", "message_info");
+    }else if(jobsToDisplay.length == 0){
+        displayMessage("No jobs to display...", "message_info");
     }else{
         removeMessage();
 


### PR DESCRIPTION
When plugin encounters a display with no jobs, it will show "Loading jobs" indefinitely. I'd like it to say what's actually going on, namely that there are no jobs to display. This change effects that behaviour.
