### PR TITLE
only show "Loading jobs..." in debug mode

### DIFF
--- a/src/main/webapp/walldisplay.js
+++ b/src/main/webapp/walldisplay.js
@@ -129,7 +129,9 @@ function repaint(){
     if(updateError != null){
         displayMessage(updateError, "message_error");
     }else if(updateRunningViews[viewName]){
-        displayMessage("Loading jobs...", "message_info");
+        if(isDebug){
+            displayMessage("Loading jobs...", "message_info");
+        }
     }else if(jobsToDisplay.length == 0){
         displayMessage("No jobs to display...", "message_info");
     }else{


### PR DESCRIPTION
we had problems with "Loading jobs..." being displayed most of the time on our CI screens.

![loading](https://cloud.githubusercontent.com/assets/36162/5692482/26ddc5e2-98f7-11e4-9920-0a5e22f6a460.png)

"Loading Jobs..." appears once an update has started but not yet finished. we think it's fine to just display the old job states at that point in time (instead of removing them and displaying that message). Once the update is complete, the new job states are repainted and almost no interruption is visible. combined with a good combination of update and paint intervals, this really improves the display of the jobs, imo.