### PR TITLE
JENKINS-23620 Screen repaint without disturbing glitches

### DIFF
--- a/src/main/webapp/walldisplay.css
+++ b/src/main/webapp/walldisplay.css
@@ -86,6 +86,11 @@ html, body {
 	width: auto;
 }
 
+#jobContainer
+{
+   visibility: hidden;
+}
+
 #Message
 {
 	border-radius: 60px;

--- a/src/main/webapp/walldisplay.html
+++ b/src/main/webapp/walldisplay.html
@@ -22,5 +22,6 @@
 </head>
 <body>
 	<div id="TextDimensionDiv"></div>
+	<div id="jobContainer"></div>
 </body>
 </html>

--- a/src/main/webapp/walldisplay.js
+++ b/src/main/webapp/walldisplay.js
@@ -138,7 +138,7 @@ function repaint(){
         removeMessage();
 
         if(!updateRunning["repaint"]){
-            removeAllJobs();
+            removeAllContainerJobs();
 
             $.each(jobsToDisplay, function(index, oldJob){
                 if(typeof oldJob !== "undefined" && typeof oldJob.visited !== "undefined" && !oldJob.visited
@@ -362,11 +362,16 @@ function repaint(){
                             showJobinfo(eventData.data.job);
                         });
 
-                        $("body").prepend(jobWrapper);
+                        $("#jobContainer").prepend(jobWrapper);
 
                         jobIndex++;
                     }
                 }
+
+                // Keeping cleanup and creation of jobs together to avoid screen flicker 
+                removeAllJobs();
+                $("body").prepend($("#jobContainer").html())
+                removeAllContainerJobs();
 
                 if(!blinkBgPicturesWhenBuilding){
                     $(".activeJob").clearQueue();
@@ -381,7 +386,11 @@ function repaint(){
 }
 
 function removeAllJobs(){
-    $(".job").remove();
+    $("body > .job").remove();
+}
+
+function removeAllContainerJobs(){
+    $("#jobContainer > .job").remove();
 }
 
 function getJobs(jobNames){


### PR DESCRIPTION
Here is possible solution for the topics commented in [JENKINS-23620](https://issues.jenkins-ci.org/browse/JENKINS-23620).
Screen glitches seemed to be caused by the time in repaint() needed between the removal of the .job-divs and the recreation.  This commit combines removal/recreation of the divs in  <body>  