### PR TITLE
Make gravatar URL configurable

### DIFF
--- a/src/main/java/de/pellepelster/jenkins/walldisplay/Configuration.java
+++ b/src/main/java/de/pellepelster/jenkins/walldisplay/Configuration.java
@@ -42,6 +42,7 @@ public class Configuration {
     private Boolean showDisabledBuilds = true;
     private Boolean showWeatherReport = false;
     private Boolean blinkBgPicturesWhenBuilding = false;
+	private String gravatarUrl = "http://www.gravatar.com/avatar/";
 
     @Exported
     public Boolean getShowBuildNumber() {
@@ -194,12 +195,21 @@ public class Configuration {
         this.customTheme = customTheme;
     }
 
+	@Exported
+	public String getGravatarUrl() {
+		return gravatarUrl;
+	}
+
+	public void setGravatarUrl(String gravatarUrl) {
+		this.gravatarUrl = gravatarUrl;
+	}
+
     /**
      * {@inheritDoc}
      */
     @Override
     public String toString() {
-        return new ToStringBuilder(this, ToStringStyle.MULTI_LINE_STYLE).append("theme", theme).append("jenkinsTimeOut", jenkinsTimeOut).append("jenkinsUpdateInterval", jenkinsUpdateInterval).append("showDetails", showDetails).append("showGravatar", showGravatar).append("fontFamily", fontFamily).append("buildRange", buildRange).append("sortOrder", sortOrder).append("showWeatherReport", showWeatherReport).toString();
+        return new ToStringBuilder(this, ToStringStyle.MULTI_LINE_STYLE).append("theme", theme).append("jenkinsTimeOut", jenkinsTimeOut).append("jenkinsUpdateInterval", jenkinsUpdateInterval).append("showDetails", showDetails).append("showGravatar", showGravatar).append("fontFamily", fontFamily).append("buildRange", buildRange).append("sortOrder", sortOrder).append("showWeatherReport", showWeatherReport).append("gravatarUrl", gravatarUrl).toString();
     }
 
     @Exported

--- a/src/main/java/de/pellepelster/jenkins/walldisplay/WallDisplayPlugin.java
+++ b/src/main/java/de/pellepelster/jenkins/walldisplay/WallDisplayPlugin.java
@@ -98,6 +98,7 @@ public class WallDisplayPlugin extends Plugin {
         config.setShowBuildNumber(formData.optBoolean("jenkinsShowBuildNumber"));
         config.setShowDetails(formData.optBoolean("jenkinsShowDetails"));
         config.setShowGravatar(formData.optBoolean("jenkinsShowGravatar"));
+		config.setGravatarUrl(formData.optString("jenkinsGravatarUrl"));
         config.setShowDisabledBuilds(formData
                 .optBoolean("jenkinsShowDisabledBuilds"));
         config.setSortOrder(Util.fixEmptyAndTrim(formData

--- a/src/main/resources/de/pellepelster/jenkins/walldisplay/WallDisplayPlugin/config.jelly
+++ b/src/main/resources/de/pellepelster/jenkins/walldisplay/WallDisplayPlugin/config.jelly
@@ -72,6 +72,10 @@
         <f:entry title="${%Show Job Show Gravatar}" name="jenkinsShowGravatar" help="${rootURL}/../plugin/jenkinswalldisplay/help-globalConfig-jenkinsShowGravatar.html">
             <f:checkbox name="jenkinsShowGravatar" checked="${it.config.showGravatar}" />
         </f:entry>
+        
+        <f:entry title="${%Custom Gravatar URL}" name="jenkinsGravatarUrl" help="${rootURL}/../plugin/jenkinswalldisplay/help-globalConfig-jenkinsGravatarUrl.html">
+            <f:textbox name="jenkinsGravatarUrl" value="${it.config.gravatarUrl}" default="http://www.gravatar.com/avatar/" />
+        </f:entry>
 
         <f:entry title="${%Show Build Number}" name="jenkinsShowBuildNumber" help="${rootURL}/../plugin/jenkinswalldisplay/help-globalConfig-jenkinsShowBuildNumber.html">
             <f:checkbox name="jenkinsShowBuildNumber" checked="${it.config.showBuildNumber}" />

--- a/src/main/webapp/help-globalConfig-jenkinsGravatarUrl.html
+++ b/src/main/webapp/help-globalConfig-jenkinsGravatarUrl.html
@@ -1,0 +1,5 @@
+<div>
+    <p>
+        Custom gravatar server URL. Default is "http://www.gravatar.com/avatar/".
+    </p>
+</div>

--- a/src/main/webapp/utils.js
+++ b/src/main/webapp/utils.js
@@ -212,11 +212,11 @@ function getJobText(job, showBuildNumber, showLastStableTimeAgo, showDetails) {
 	return jobText;
 }
 
-function getGravatarUrl(job, showGravatar, size) {
+function getGravatarUrl(job, showGravatar, size, gravatarUrl) {
     if(showGravatar && getEmail(job) !== "") {
         var hash = CryptoJS.MD5(getEmail(job).toLowerCase());
 
-        return "http://www.gravatar.com/avatar/" + hash + "?s=" + size;
+        return (gravatarUrl != null && gravatarUrl != "" ? gravatarUrl : "http://www.gravatar.com/avatar/") + hash + "?s=" + size;
     }
 }
 function getEmail(job) {

--- a/src/main/webapp/walldisplay.js
+++ b/src/main/webapp/walldisplay.js
@@ -247,7 +247,8 @@ function repaint(){
                         if(!jobGravatarCache[job.name] || gravatarCounter[job.name] >= 5){
                             var jobGravatar = $('<img />');
                             jobGravatar.attr('src', getGravatarUrl(job, showGravatar, Math
-                                .round(jobDimensions.height * 0.80)));
+                                .round(jobDimensions.height * 0.80), gravatarUrl));
+                            jobGravatar.attr('alt', getEmail(job));
                             jobGravatar.css({
                                 "float": "left",
                                 "padding-top": Math.round((jobDimensions.height * 0.50)
@@ -772,6 +773,10 @@ function getPluginConfiguration(jenkinsUrl){
                     showGravatar = getParameterByName('showGravatar', plugin.config.showGravatar);
                 }
 
+                if(plugin.config.gravatarUrl != null){
+                    gravatarUrl = getParameterByName('gravatarUrl', plugin.config.gravatarUrl);
+                }
+
                 if(plugin.config.showBuildNumber != null){
                     showBuildNumber = getParameterByName('showBuildNumber', plugin.config.showBuildNumber);
                 }
@@ -886,6 +891,7 @@ var buildRange = getParameterByName("buildRange", "all");
 var customTheme = getParameterByName("customTheme", null);
 var showDetails = false;
 var showGravatar = false;
+var gravatarUrl = "http://www.gravatar.com/avatar/";
 var jobGravatarCache = {};
 var gravatarCounter = {};
 var showBuildNumber = true;


### PR DESCRIPTION
Added support for custom Gravatar URLs, for users running their own avatar server compatible with gravatar (e.g. Confluence with the avatar server plugin). This adds a new configuration option, which defaults to gravatar.com base URL.